### PR TITLE
Enable GitHub Pages redirect

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="refresh" content="0; url=../index.html" />
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>If you are not redirected automatically, <a href="../index.html">click here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `docs/` folder
- redirect `docs/index.html` to repo root for GitHub Pages

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/`
- `curl -I http://localhost:8000/docs/`

------
https://chatgpt.com/codex/tasks/task_e_685ef358f6208333a0daab1d8a183d62