### PR TITLE
Fix herbalism time target calculation

### DIFF
--- a/js/activities.js
+++ b/js/activities.js
@@ -87,10 +87,11 @@ const activities = {
 				return [];
 			}
 		},
-		timeTarget: function() {
-			this.currentHerb = getRandomHerb(this.variableValues.herbs);
-			this.timeTarget = herbs[this.currentHerb].difficulty;
-		},
+               timeTarget: function() {
+                       this.currentHerb = getRandomHerb(this.variableValues.herbs);
+                       const herbDifficulty = findHerbByName(this.currentHerb).difficulty;
+                       return herbDifficulty;
+               },
 		timeTargetMultiplier: "pickFlowersSpeedTargetMultiplier",
 		workPer: 1,
 		workMultiplier: "pickFlowersSpeedMultiplier",


### PR DESCRIPTION
## Summary
- use `findHerbByName` when determining herb difficulty
- return difficulty from herbalism timeTarget function

## Testing
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_685ef2fe42ac8333ad37ab4de9d26b3f