### PR TITLE
Fix gainResource rounding behavior

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -219,7 +219,7 @@ function gainResource(character, resource, amount, integerOnly = false){
     let amountToAdd;
 
     if(integerOnly){
-        amountToAdd = amount | 0;
+        amountToAdd = Math.round(amount);
     } else {
         amountToAdd = Number.parseFloat(amount.toPrecision(2));
     }


### PR DESCRIPTION
## Summary
- use `Math.round` instead of truncation for `gainResource`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ef2fecd808333b286d3bd93ed86b4