### PR TITLE
Add Jest test for Travel cost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ nbproject/private/private.properties
 nbproject/project.properties
 nbproject/project.xml
 nbproject/private/private.xml
+node_modules/
+package-lock.json
+npm.log
+test.log
+

--- a/js/travel.js
+++ b/js/travel.js
@@ -36,3 +36,5 @@ class Travel {
         ];
     }
 }
+
+module.exports = Travel;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "incrementalexploration",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^30.0.3",
+    "yargs-parser": "^21.1.1"
+  }
+}

--- a/tests/travel.test.js
+++ b/tests/travel.test.js
@@ -1,0 +1,6 @@
+const Travel = require('../js/travel');
+
+test('walking cost', () => {
+  const travel = new Travel('walking');
+  expect(travel.getTravelCost(5)).toBe(5);
+});


### PR DESCRIPTION
## Summary
- set up Jest via package.json
- export `Travel` class for use in tests
- ignore node_modules and logs
- add basic test to verify walking travel cost

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ef2ff4e8c833395ee7a03deede599