### PR TITLE
Add gh-pages instructions and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # incrementalExploration
+
+This project is a small JavaScript game. To publish the site using GitHub Pages you can create a `gh-pages` branch that contains the latest build of the web assets.
+
+## Publishing to GitHub Pages
+
+A helper script `publish-gh-pages.sh` is included for convenience. It uses a temporary `git worktree` to update the `gh-pages` branch.
+
+Run the following commands from the repository root:
+
+```bash
+# First time setup (creates the branch if it doesn't exist)
+./publish-gh-pages.sh
+```
+
+This will copy `index.html`, `css`, `js`, `modules`, and the `docs` folder to the `gh-pages` branch and push it to `origin`.
+
+After running the script, configure GitHub Pages in the repository settings to serve from the `gh-pages` branch.

--- a/publish-gh-pages.sh
+++ b/publish-gh-pages.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# This script publishes the current repository to the gh-pages branch
+# using a temporary worktree. Run this script from the repository root.
+
+worktree_dir=".gh-pages-worktree"
+
+# Remove any previous worktree
+if [ -d "$worktree_dir" ]; then
+  git worktree remove -f "$worktree_dir"
+fi
+
+# Create worktree for gh-pages branch
+git worktree add "$worktree_dir" gh-pages || git worktree add -B gh-pages "$worktree_dir" origin/gh-pages
+
+# Clear old contents
+rm -rf "$worktree_dir"/*
+
+# Copy website files
+cp -r index.html css js modules docs "$worktree_dir"/
+
+# Commit and push
+cd "$worktree_dir"
+git add .
+commit_msg="Deploy $(date +'%Y-%m-%d %H:%M:%S')"
+if ! git diff --quiet --cached; then
+  git commit -m "$commit_msg"
+  git push origin gh-pages
+else
+  echo "No changes to publish"
+fi
+
+# Return to repo root
+cd ..
+
+# Remove worktree
+git worktree remove "$worktree_dir"


### PR DESCRIPTION
## Summary
- add instructions for publishing to GitHub Pages
- provide `publish-gh-pages.sh` helper script to create/update the `gh-pages` branch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f028d4ad88333ae162a1886f0c05e