### PR TITLE
Implement basic modern UI skeleton

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -14,7 +14,91 @@
 @import url('https://fonts.googleapis.com/css?family=Montserrat&display=swap');
 
 * {
-	box-sizing: border-box;
+        box-sizing: border-box;
+}
+
+:root {
+    --accent-500: #3b82f6;
+    --neutral-50: #f5f5f5;
+    --neutral-800: #1f2937;
+    --radius: 12px;
+    --shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+body {
+    margin: 0;
+    font-family: 'Montserrat', sans-serif;
+    background: var(--neutral-50);
+    color: var(--neutral-800);
+}
+
+/* HUD */
+#hud {
+    position: sticky;
+    top: 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 16px;
+    background: #fff;
+    box-shadow: var(--shadow);
+    z-index: 100;
+}
+
+.icon-button {
+    background: none;
+    border: none;
+    font-size: 1.2rem;
+    margin-left: 8px;
+    cursor: pointer;
+}
+
+/* Drawers */
+.drawer {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    background: #fff;
+    box-shadow: var(--shadow);
+    transition: transform .3s ease;
+    z-index: 90;
+}
+.drawer.collapsed {
+    width: 48px;
+    transform: translateX(0);
+}
+.drawer:not(.collapsed) {
+    width: 220px;
+}
+.drawer.right {
+    right: 0;
+    transform: translateX(100%);
+    width: 300px;
+}
+.drawer.right.open {
+    transform: translateX(0);
+}
+
+.drawer-toggle {
+    width: 48px;
+    height: 48px;
+    background: var(--accent-500);
+    color: #fff;
+    border: none;
+    cursor: pointer;
+}
+
+.drawer-content {
+    padding: 8px;
+}
+
+/* Toast */
+.toast {
+    opacity: 0;
+    transition: opacity .3s ease;
+}
+.toast.show {
+    opacity: 1;
 }
 
 #ActivityContainer {

--- a/index.html
+++ b/index.html
@@ -3,33 +3,34 @@
 
 <head>
     <title>Click Test</title>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <link rel="stylesheet" type="text/css" href="css/style.css"/>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-          integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 </head>
 
 <body>
-<div class="container">
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand" href="#">Incremental Game</a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
-                aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav">
-                <li class="nav-item">
-                    <a class="nav-link" id="homeButton">Home</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="#" data-tab="stats">View Stats</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="#" data-tab="settings">Settings</a>
-                </li>
-            </ul>
-        </div>
+<header id="hud" data-testid="hud">
+    <div class="hud-resources">
+        <span id="hudGold" data-testid="hud-gold">Gold: 0</span>
+        <span id="hudEnergy" data-testid="hud-energy">Energy: 0</span>
+        <span id="hudXp" data-testid="hud-xp">XP: 0</span>
+    </div>
+    <div class="hud-actions">
+        <button id="statsIcon" class="icon-button" data-testid="statsIcon">📈</button>
+        <button id="settingsIcon" class="icon-button" data-testid="settingsIcon">⚙️</button>
+        <button id="prestigeIcon" class="icon-button" data-testid="prestigeIcon">★</button>
+    </div>
+</header>
+
+<aside id="navDrawer" class="drawer collapsed" data-testid="leftDrawer">
+    <button id="drawerToggle" class="drawer-toggle" data-testid="drawerToggle">☰</button>
+    <nav class="drawer-content">
+        <button class="drawer-item" data-testid="drawer-locations">📍</button>
+        <button class="drawer-item" id="drawer-stats" data-testid="drawer-stats">📊</button>
     </nav>
+</aside>
+
+<div class="container" id="mainContainer" data-testid="mainContainer">
     <div id="locationContainer">
         <div class="row">
             <div class="col-md-8">
@@ -57,7 +58,7 @@
             </div>
         </div>
     </div>
-    <div id="statsContainer" style="display: none">
+    <aside id="statsPanel" class="drawer right" data-testid="statsPanel">
         <div class="row">
             <div class="col-md-12">
                 <div class="card">
@@ -93,14 +94,14 @@
                 </div>
             </div>
         </div>
-    </div>
-    <div id="settingsContainer" style="display: none">
+    </aside>
+    <aside id="settingsPanel" class="drawer right" data-testid="settingsPanel">
         <h3>Settings</h3>
         <p>Save and manage your game data.</p>
         <button class="btn btn-primary" id="saveButton">Save Game</button>
         <button class="btn btn-warning" id="autosaveButton">Toggle Autosave</button>
         <button class="btn btn-danger" id="deleteButton">Delete Save</button>
-    </div>
+    </aside>
     <div class="row" style="margin-top: 20px;">
         <div class="col-md-12">
                 <div class="card">
@@ -119,16 +120,14 @@
 </div>
 
 <script src="./modules/jquery-3.6.0.min.js"></script>
-<script src="./modules/popper.min.js"></script>
-<script src="./modules/bootstrap.min.js"></script>
 <script src="./modules/gsap.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
 <script src="js/locations.js" type="text/javascript"></script>
 <script src="js/activities.js" type="text/javascript"></script>
 <script src="js/character.js" type="text/javascript"></script>
 <script src="js/travel.js" type="text/javascript"></script>
 <script src="js/items.js" type="text/javascript"></script>
 <script src="js/herbalism.js" type="text/javascript"></script>
+<script src="js/ui.js" type="text/javascript"></script>
 <script src="js/game.js" type="text/javascript"></script>
 
 </body>

--- a/js/game.js
+++ b/js/game.js
@@ -281,7 +281,12 @@ function setActivityMessage(message) {
 
     const activityText = document.getElementById("activityText");
     activityText.innerHTML = message;
-    $('.toast').toast('show');
+
+    const toast = document.querySelector('.toast');
+    if (toast) {
+        toast.classList.add('show');
+        setTimeout(() => toast.classList.remove('show'), 5000);
+    }
 }
 
 /*** MAIN LOOP ****************************************/
@@ -528,7 +533,7 @@ settingsButton.addEventListener("click", () => {
 $(function() {
     $('#toastClose').on("click", function() {
         console.log("Clicked");
-        $('.toast').toast('hide');
+        $('.toast').removeClass('show');
     });
 
     $("#saveButton").on("click", saveGame);

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,11 @@
+$(function(){
+    $('#statsIcon').on('click', function(){
+        $('#statsPanel').toggleClass('open');
+    });
+    $('#settingsIcon').on('click', function(){
+        $('#settingsPanel').toggleClass('open');
+    });
+    $('#drawerToggle').on('click', function(){
+        $('#navDrawer').toggleClass('collapsed');
+    });
+});


### PR DESCRIPTION
## Summary
- remove Bootstrap from index
- add fixed HUD header and left navigation drawer
- convert stats and settings to slide-in panels
- implement simple jQuery UI toggles
- add modern CSS variables and drawer styling
- custom toast logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f6e7be47c833381f6e73c804e4c6f